### PR TITLE
(MAINT) Add root user for installing packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM puppet/pdk:latest
 
+USER root
+
 RUN apt-get update && \
     apt-get install -y curl && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Instead of relying on the base image to have the root user as default, this sets the root user explicitly for installing packages, prior to creating and switching to the anubis user.