### PR TITLE
(FIXUP) Fix erroneous lint error reporting

### DIFF
--- a/entrypoints/puppet-lint
+++ b/entrypoints/puppet-lint
@@ -13,6 +13,15 @@ if [[ ! -d "$DIR" ]]; then DIR="$PWD"; fi
 # shellcheck source=../shared/entrypoint-anubis-pre disable=SC1091
 . "$DIR/../shared/entrypoint-anubis-pre"
 
+# puppet-lint reports incorrect autoloader_layout errors if the current directory is not the
+# same as the module name, so we need to get just the module name (no author name, no version number)
+# from $release_slug and update the name of the current directory.
+[[ $release_slug =~ [a-zA-Z0-9]+-([a-zA-Z][a-zA-Z0-9_]+)-[0-9]+\.[0-9]+\.[0-9]+([\-+].+)? ]]
+modname=${BASH_REMATCH[1]}
+mv "$PWD" "${PWD%/*}/${modname}"
+cd ..
+cd $modname
+
 manifests=0
 lines=0
 


### PR DESCRIPTION
The puppet-lint script was incorrectly reporting autoloader_layout errors due to the directory name not matching the module name. This commit extracts the module name from the full release slug, and renames the directory from which puppet-lint is run.