### PR TITLE
(FIXUP) Remove custom config for puppet-lint

### DIFF
--- a/entrypoints/puppet-lint
+++ b/entrypoints/puppet-lint
@@ -35,6 +35,9 @@ fi
 
 eval $(pdk env)
 
+# Remove any custom config if present
+rm -f -- .puppet-lint.rc
+
 # Run lint and emit output to json document
 {
   puppet-lint --json manifests > lint_output.json


### PR DESCRIPTION
The puppet-lint evaluation was failing on some releases where custom config for puppet-lint was present and required a plugin that was not installed. This removes any local puppet-lint config file prior to running puppet-lint on files in the manifests directory.