### PR TITLE
(SPIKE) Add malware-scan entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM puppet/pdk:latest
 USER root
 
 RUN apt-get update && \
-    apt-get install -y curl && \
+    apt-get install -y curl jq && \
     rm -rf /var/lib/apt/lists/*
 
 RUN ["useradd", "--create-home", "--home-dir", "/anubis", "--shell", "/bin/bash", "--user-group", "anubis"]

--- a/entrypoints/malware-scan
+++ b/entrypoints/malware-scan
@@ -1,0 +1,73 @@
+#!/bin/bash
+set -e
+
+# TODO: This doesn't need the pdk, so we could consider splitting it out into another Dockerfile.
+# It does leverage the pre and post scripts though, so we'd want to keep those available.
+# Establish source dir for relative includes
+DIR="${BASH_SOURCE%/*}"
+if [[ ! -d "$DIR" ]]; then DIR="$PWD"; fi
+
+# Pre-suite (download and extract requested release)
+# shellcheck source=../shared/entrypoint-pre disable=SC1091
+. "$DIR/../shared/entrypoint-pre"
+
+# Make sure required Anubis env vars are set
+# shellcheck source=../shared/entrypoint-anubis-pre disable=SC1091
+. "$DIR/../shared/entrypoint-anubis-pre"
+
+# A VirusTotal key is required to utilize their API
+: "${VIRUSTOTAL_KEY:?Need to set VIRUSTOTAL_KEY}"
+tarball_path="../$release_slug.tar.gz"
+
+# Check the tarball file size, and if larger than 32 MB, need to request a dedicated upload URL.
+tarball_size=$(du -m "$tarball_path" | cut -f1)
+if [[ tarball_size -gt 32 ]] ; then
+  upload_url_request=$(curl --request GET \
+    --url "https://www.virustotal.com/api/v3/files/upload_url" \
+    --header "x-apikey: $VIRUSTOTAL_KEY")
+
+  upload_url=$(echo $upload_url_request | jq --raw-output '.data')
+else
+  upload_url='https://www.virustotal.com/api/v3/files'
+fi
+
+upload=$(curl --request POST \
+  --url $upload_url \
+  --header "x-apikey: $VIRUSTOTAL_KEY" \
+  --form file=@"$tarball_path")
+
+result_id=$(echo $upload | jq --raw-output '.data.id')
+
+# Wait a little bit to allow the analysis to run
+sleep 30
+
+# Loop 10 times or until .data.attributes.status is not "queued"
+queued=true
+num_requests=0
+while [[ $num_requests -lt 10 && "$queued" = true ]] ; do
+  result=$(curl --request GET \
+    --url "https://www.virustotal.com/api/v3/analyses/$result_id" \
+    --header "x-apikey: $VIRUSTOTAL_KEY")
+
+  result_status=$(echo $result | jq --raw-output '.data.attributes.status')
+  if [[ "$result_status" != 'queued' ]] ;
+  then
+    queued=false
+  else
+    sleep 20
+  fi
+
+  let num_requests=num_requests+1
+done
+
+echo $result > anubis_output.json
+cat anubis_output.json
+
+# Post results back to given API endpoint
+# shellcheck source=../shared/entrypoint-anubis-post disable=SC1091
+. "$DIR/../shared/entrypoint-anubis-post"
+
+# shellcheck source=shared/entrypoint-post disable=SC1091
+. "$DIR/../shared/entrypoint-post"
+
+exit 0


### PR DESCRIPTION
This draft shows the basics of using the virustotal API to run checks within Anubis. I was able to run this locally and get the completed results posted back to my local Forge API.

We could look into running this as a local que job on the app servers, but my first pass at running this just within the API publish helper was proving a bit difficult - specifically, I had trouble getting the file data into a format acceptable to the virustotal API without writing it to disk. We could probably look into that further if desired for the non-spike ticket, but this at least outlines the basic series of requests we'd need to make.